### PR TITLE
Add wireless packet decoding utilities

### DIFF
--- a/secplus.h
+++ b/secplus.h
@@ -35,6 +35,34 @@ extern int8_t encode_wireline(uint32_t rolling, uint64_t fixed, uint32_t data,
 extern int8_t decode_wireline(const uint8_t *packet, uint32_t *rolling,
                               uint64_t *fixed, uint32_t *data);
 
+extern int8_t encode_wireline_command(uint32_t rolling, uint64_t device_id,
+                                      uint16_t command, uint32_t payload,
+                                      uint8_t *packet);
+
+extern int8_t decode_wireline_command(const uint8_t *packet, uint32_t *rolling,
+                                      uint64_t *device_id, uint16_t *command,
+                                      uint32_t *payload);
+typedef struct {
+  uint8_t door;
+  uint8_t learn;
+  uint8_t unk1;
+  uint8_t unk2;
+  uint8_t light;
+  uint8_t lock;
+  uint8_t blocked;
+  uint8_t unk3;
+} secplus_status_t;
+
+extern int8_t decode_wireless_command(const uint8_t *packet1,
+                                      const uint8_t *packet2, uint32_t *rolling,
+                                      uint64_t *device_id, uint8_t *button,
+                                      uint8_t *switch_number, uint16_t *command,
+                                      uint32_t *payload);
+
+extern uint8_t secplus_wireless_pressed(uint32_t payload);
+extern void secplus_wireless_parse_status(uint32_t payload,
+                                          secplus_status_t *status);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- add helpers to decode Security+ 2.0 wireless packets and extract device ID, button, switch number, command and payload
- expose status parsing struct and utilities to interpret door/light/lock bits and surface three unknown flags