### PR TITLE
Expose remote identifier in callbacks

### DIFF
--- a/examples/main/main.c
+++ b/examples/main/main.c
@@ -17,6 +17,7 @@
 
 #include "esp_log.h"
 #include "gdo.h"
+#include <inttypes.h>
 
 static const char *TAG = "test_main";
 
@@ -58,10 +59,12 @@ static void gdo_event_handler(const gdo_status_t* status, gdo_cb_event_t event, 
         ESP_LOGI(TAG, "Motion: %s", gdo_motion_state_to_string(status->motion));
         break;
     case GDO_CB_EVENT_BATTERY:
-        ESP_LOGI(TAG, "Battery: %s", gdo_battery_state_to_string(status->battery));
+        ESP_LOGI(TAG, "Remote %" PRIu32 " battery: %s", status->remote_id,
+                 gdo_battery_state_to_string(status->battery));
         break;
     case GDO_CB_EVENT_BUTTON:
-        ESP_LOGI(TAG, "Button: %s", gdo_button_state_to_string(status->button));
+        ESP_LOGI(TAG, "Remote %" PRIu32 " button: %s", status->remote_id,
+                 gdo_button_state_to_string(status->button));
         break;
     case GDO_CB_EVENT_MOTOR:
         ESP_LOGI(TAG, "Motor: %s", gdo_motor_state_to_string(status->motor));

--- a/gdo.c
+++ b/gdo.c
@@ -89,6 +89,7 @@ static gdo_status_t g_status = {
     .door_target = -1,
     .client_id = 0x666,
     .rolling_code = 0,
+    .remote_id = 0,
     .toggle_only = false,
     .last_move_direction = GDO_DOOR_STATE_UNKNOWN,
 };
@@ -1342,12 +1343,15 @@ static void decode_packet(uint8_t *packet) {
 
     data &= ~0xf000;
 
-    if ((fixed & 0xFFFFFFFF) == g_status.client_id) { // my commands
+    uint32_t remote_id = (uint32_t)(fixed & 0xFFFFFFFF);
+    if (remote_id == g_status.client_id) { // my commands
         ESP_LOGE(TAG, "received mine: rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, rolling, fixed, data);
         return;
     } else {
         ESP_LOGI(TAG, "received rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, rolling, fixed, data);
     }
+
+    g_status.remote_id = remote_id;
 
     gdo_command_t cmd = ((fixed >> 24) & 0xf00) | (data & 0xff);
     uint8_t nibble = (data >> 8) & 0xff;

--- a/include/gdo.h
+++ b/include/gdo.h
@@ -136,7 +136,7 @@ typedef struct {
     gdo_obstruction_state_t obstruction; // Obstruction state
     gdo_motor_state_t motor; // Motor state
     gdo_button_state_t button; // Button state
-    gdo_battery_state_t battery; // Battery state
+    gdo_battery_state_t battery; // Battery state of the last remote
     gdo_learn_state_t learn; // Learn state
     gdo_paired_device_t paired_devices; // Paired devices
     bool synced; // Synced state
@@ -148,6 +148,7 @@ typedef struct {
     int32_t door_target; // Door target position in percentage (0-10000) [OPEN-CLOSED]
     uint32_t client_id; // Client ID
     uint32_t rolling_code; // Rolling code
+    uint32_t remote_id; // Identifier of the last remote that triggered an event
     bool toggle_only; // Used when the door opener only supports the toggle command.
     gdo_door_state_t last_move_direction; // Last move direction
 } gdo_status_t;


### PR DESCRIPTION
## Summary
- include the last remote's identifier in `gdo_status_t` so callbacks can know which remote triggered an event
- log remote id with button and battery callbacks in the example app